### PR TITLE
Fix: the name of the webpack config changed, to the eslintignore need…

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 app/build/
 app/dist/
-webpack.config.js
+webpack.config.*.js

--- a/config/generators/page/index.js
+++ b/config/generators/page/index.js
@@ -53,7 +53,7 @@ module.exports = {
       type: 'modify',
       path: '../../app/containers/index.js',
       pattern: /(\/\* Assemble all containers for export \*\/)/g,
-      template: trimTemplateFile('route.js.hbs'),
+      template: trimTemplateFile('./page/route.js.hbs'),
     });
 
     return actions;

--- a/config/generators/page/index.js.hbs
+++ b/config/generators/page/index.js.hbs
@@ -1,6 +1,29 @@
-/**
- * Page Generator index.js template
- * (leave blank for now)
- * TODO : Figure out how to connect route to redux.
- *        Should we also generate a Container in the containers folder for each new Route ?
- */
+import React from 'react';
+{{#if wantSCSSModules}}
+import cssModules from 'react-css-modules';
+import styles from './index.module.scss';
+{{/if}}
+// Example to import a component using ES6 destructuring.
+/* eslint-disable*/ // Containers is an alias, so no file is found
+import { {{ properCase name }}Container } from 'containers';
+/* eslint-enable */
+
+ // Pages map directly to Routes, i.e. one page equals on Route
+ // Handler that maps to a route in /utils/routes
+ const LandingPage = (props) => (
+   {{#if wantSCSSModules}}
+   <div className={{curly true}}styles.{{ camelCase name }}{{curly}}>
+   {{else}}
+   <div>
+   {{/if}}
+     <{{ properCase name }}Container
+       {...props}
+     />
+   </div>
+ );
+
+{{#if wantSCSSModules}}
+export default cssModules({{ properCase name }}, styles);
+{{else}}
+export default {{ properCase name }};
+{{/if}}

--- a/config/generators/page/index.module.scss.hbs
+++ b/config/generators/page/index.module.scss.hbs
@@ -1,0 +1,3 @@
+.{{ camelCase name }} {
+
+}


### PR DESCRIPTION
…ed to be updated

* The ignore file now points to webpack.config.*.js to act as a catchall
* Also, I added some boilerplate for the page component but did not totally finish it because I wasn't sure what still needed to be done with the setup since running the generator for pages causes a bug where the route.js.hbs is not found.