### PR TITLE
Fix: update package.json to set the proper testing webpack file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "plugins": [
           [
             "babel-plugin-webpack-loaders", {
-              "config": "./config/testing/webpack.test.config.js",
+              "config": "./config/webpack/webpack.test.config.js",
               "verbose": false
             }
           ],


### PR DESCRIPTION
The webpack config for testing was removed and in the cases where the babel-plugin webpack loaders were used the test suit would fail.

See #49 