### PR TITLE
Add deploy to netlify button

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Follow the onscreen instructions to create your app.
 
 ## Deployment
 
+<a href="https://app.netlify.com/start/deploy?repository=https://github.com/RyanCCollins/scalable-react-boilerplate">
+  <img src="https://www.netlify.com/img/deploy/button.svg" title="Deploy to Netlify">
+</a>
+
 <a href="https://myrskyt.com/container/deploy/https://github.com/RyanCCollins/scalable-react-boilerplate"><img src="https://myrskyt.com/static/img/button.jpg" height="40" width="155"></a>
 
 A demo ExpressJS setup is included with the app.  The express server will serve up the production minified bundle.js, index.html and any other assets that are located in the `/server/public` folder.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "server/public"


### PR DESCRIPTION
I opened this PR to add a Netlify example and one click deploy button. The netlify.toml file just populates the build command bundle output location.

test out the button here:

<!-- Markdown snippet -->
[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/scalable-react-boilerplate)

Let me know if you have any questions. Also if you have interest we offer a [free plan](https://www.netlify.com/open-source/) at Netlify for all open source projects, check out the details here if you are interested in using it for scalable--react-boilerplate examples.
