### PR TITLE
Fix #75: Update template for stateless components

### DIFF
--- a/config/generators/component/stateless.js.hbs
+++ b/config/generators/component/stateless.js.hbs
@@ -26,8 +26,8 @@ function {{ properCase name }}(props: {}) {
     </Box>
   );
 }
-{{else if wantPropTypes}}
-{{#unless wantFlowTypes}}
+{{else}}
+{{#if wantPropTypes}}
 function {{ properCase name }}(props) {
   return (
     <Box>
@@ -35,7 +35,6 @@ function {{ properCase name }}(props) {
     </Box>
   );
 }
-{{/unless}}
 {{else}}
 function {{ properCase name }}() {
   return (
@@ -44,6 +43,7 @@ function {{ properCase name }}() {
     </Box>
   );
 }
+{{/if}}
 {{/if}}
 
 {{#if wantPropTypes}}

--- a/config/generators/component/styles.js.hbs
+++ b/config/generators/component/styles.js.hbs
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+// eslint-disable-next-line import/prefer-default-export
 export const StyledWrapper = styled.section`
   margin: 10px;
 `;

--- a/config/generators/container/actions.js.hbs
+++ b/config/generators/container/actions.js.hbs
@@ -27,7 +27,7 @@ export const loadDataSuccess = () => ({
   type: T.LOAD_DATA_SUCCESS,
 });
 
-export const loadDataFailure = (error) => ({
+export const loadDataFailure = error => ({
   type: T.LOAD_DATA_FAILURE,
   error,
 });

--- a/config/generators/container/styles.js.hbs
+++ b/config/generators/container/styles.js.hbs
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+// eslint-disable-next-line import/prefer-default-export
 export const StyledWrapper = styled.section`
   margin: 10px;
 `;


### PR DESCRIPTION
The `{{else if ...}}` construct is not supported prior to handlebars v3.0.0. Based on yarn.lock, seems like plop is using handlebars 2.0.0.

* Replace `{{else if ...}}` with a nested `if/else` block
* Remove unnecessary branch point on `{{#unless wantFlowTypes}}` which will never be reached since that condition is already checked in an earlier `if` condition.